### PR TITLE
Start gracefully when the Veeam product is unreachable at startup

### DIFF
--- a/src/mcp/__tests__/toolFactory.test.ts
+++ b/src/mcp/__tests__/toolFactory.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright © Veeam Software Group GmbH. All rights reserved.
+ * Licensed under the MIT License. See LICENSE in the project root for license information.
+ */
+
+import { describe, it, expect, beforeAll } from '@jest/globals';
+import { ChatbotMode } from '@/common/types';
+
+// Point at an unreachable backend (the reserved `.invalid` TLD never resolves,
+// per RFC 2606) so the startup getServiceInfo() call fails — exercising the
+// graceful fallback path directly, without module mocking. Set before the
+// dynamic import below so settings parse succeeds.
+process.env.PRODUCT_NAME = 'vbr';
+process.env.WEB_URL = 'https://vbr.unreachable.invalid:9419';
+process.env.ADMIN_USERNAME = 'x';
+process.env.ADMIN_PASSWORD = 'x';
+process.env.ACCEPT_SELF_SIGNED_CERT = 'true';
+
+let createTool: typeof import('../toolFactory').createTool;
+
+beforeAll(async () => {
+    ({ createTool } = await import('../toolFactory'));
+});
+
+describe('createTool — graceful startup', () => {
+    it('does not throw when the Veeam product is unreachable at startup', async () => {
+        // Before this fix, an unreachable backend threw here and crashed the
+        // whole MCP server at boot. Now it resolves with default metadata so
+        // the server starts, advertises its tool, and defers auth to call time.
+        const cfg = await createTool();
+        expect(cfg.mode).toBe(ChatbotMode.Advanced);
+        expect(cfg.title).toBe('Answer Veeam Question');
+        expect(cfg.description).toContain('Veeam');
+    });
+});

--- a/src/mcp/toolFactory.ts
+++ b/src/mcp/toolFactory.ts
@@ -14,10 +14,28 @@ interface ToolConfig {
 }
 
 export async function createTool(): Promise<ToolConfig> {
-    const productRestClient = createProductRestClient();
-    const serviceInfo = await productRestClient.getServiceInfo();
+    try {
+        const productRestClient = createProductRestClient();
+        const serviceInfo = await productRestClient.getServiceInfo();
 
-    return createToolMetadata(serviceInfo.chatbotMode);
+        return createToolMetadata(serviceInfo.chatbotMode);
+    } catch (error) {
+        // The Veeam product may not be reachable at startup — e.g. the MCP
+        // server is launched before connectivity is established, or it is run
+        // behind a network tunnel / by an MCP client that expects `tools/list`
+        // to succeed without a live backend. Detecting the chatbot mode is the
+        // ONLY reason we contact the product here, and it affects nothing but a
+        // runtime advisory (the tool description is identical in both modes).
+        // So rather than crash the process, start with default (advanced) tool
+        // metadata; the tool handler authenticates on demand and surfaces any
+        // connectivity/auth error as a normal tool error at call time.
+        const cause = error instanceof Error ? error.message : String(error);
+        console.error(
+            `[veeam-mcp] Could not reach the Veeam product at startup to detect chatbot mode; ` +
+                `starting with default tool metadata. Tool calls will authenticate on demand. Cause: ${cause}`,
+        );
+        return createToolMetadata(ChatbotMode.Advanced);
+    }
 }
 
 function createToolMetadata(mode: ChatbotMode): ToolConfig {


### PR DESCRIPTION
## Problem

`createTool()` contacts the Veeam product at startup — via `getServiceInfo()` — solely to read `chatbotMode`. Because the call is `await`ed at module top level in `index.ts`, **any** failure (backend unreachable, wrong URL, credentials not yet valid, product still booting) throws and crashes the entire MCP server before it can serve a single request. An MCP client connecting to it can't even `initialize` / `tools/list`; it just sees the process exit.

Reproduction (unreachable backend):

```
Authentication failed: getaddrinfo ENOTFOUND <web_url_host>
Error: Axios error during authentication.
  at VbrRestClient.authenticate (...)
  → process exits before the transport connects
```

## Fix

The startup call to the backend exists only to detect `chatbotMode`, and that mode affects **nothing but a runtime advisory** — the tool description is identical in both modes, and the tool handler (`answerQuestion`) already authenticates lazily on each call. So there's no need to reach the backend at startup.

`createTool()` now wraps the detection in `try/catch`: on failure it logs a warning and returns default (advanced) tool metadata, so the server **starts, advertises its tool, and defers authentication to call time** — where a real connectivity/auth problem surfaces as a normal tool error instead of a boot crash.

This also makes the server usable in setups where the product isn't reachable at the moment of launch: starting before the product is up, or running the server behind a network tunnel / on a host that reaches the product on demand.

## Behavior

- **Before:** unreachable product at startup → process crash, no tools served.
- **After:** server starts; `tools/list` returns `veeam-question-answering`; a `[veeam-mcp] Could not reach the Veeam product at startup …` warning is logged to stderr; tool calls authenticate on demand.
- When the product **is** reachable at startup, behavior is unchanged (real `chatbotMode` is used, including the Base-mode advisory).

## Tests / checks

- New unit test `src/mcp/__tests__/toolFactory.test.ts` covering the unreachable-at-startup path.
- `npm run ci` (format + lint + typecheck) passes; full `npm test` — 42/42 pass.